### PR TITLE
Update global line height

### DIFF
--- a/src/sass/standard/base/_typography.sass
+++ b/src/sass/standard/base/_typography.sass
@@ -26,7 +26,7 @@ $alignment: center left right
   font-family: $font-family
   color: $text-color
   font-size: ms(1)
-  line-height: 1.33333333333333
+  line-height: ms(1.3)
 
 h1, h2, h3, h4, h5, h6, p, ul, ol, li
   margin-top: 0

--- a/src/sass/standard/base/_typography.sass
+++ b/src/sass/standard/base/_typography.sass
@@ -26,7 +26,7 @@ $alignment: center left right
   font-family: $font-family
   color: $text-color
   font-size: ms(1)
-  line-height: ms(1)
+  line-height: 1.33333333333333
 
 h1, h2, h3, h4, h5, h6, p, ul, ol, li
   margin-top: 0


### PR DESCRIPTION
In a design review with Chris Curry he mentioned that the default line-height shouldn't be the same as the font-size. Currently our default font-size is `15px` and Chris wants the line-height at `20px`. It's not _quite_ that easy since we use a bunch of relative units, but `15 * 1.33333333` is roughly 20.

UPDATE: Chris suggested we use `ms(1.3)` which is basically the same as the above ^